### PR TITLE
Add at-here to default mentions list in Notifications test

### DIFF
--- a/src/test/html/AccountSettingsNotifications.html
+++ b/src/test/html/AccountSettingsNotifications.html
@@ -342,7 +342,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>id=Words_that_trigger_mentionsDesc</td>
-	<td>&quot;@test&quot;, &quot;test&quot;, &quot;@channel&quot;, &quot;@all&quot;</td>
+	<td>&quot;@test&quot;, &quot;test&quot;, &quot;@channel&quot;, &quot;@all&quot;, &quot;@here&quot;</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -374,7 +374,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>id=Words_that_trigger_mentionsDesc</td>
-	<td>&quot;@test&quot;, &quot;@channel&quot;, &quot;@all&quot;</td>
+	<td>&quot;@test&quot;, &quot;@channel&quot;, &quot;@all&quot;, &quot;@here&quot;</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -513,7 +513,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>id=Words_that_trigger_mentionsDesc</td>
-	<td>&quot;@test&quot;, &quot;test&quot;, &quot;@channel&quot;, &quot;@all&quot;</td>
+	<td>&quot;@test&quot;, &quot;test&quot;, &quot;@channel&quot;, &quot;@all&quot;, &quot;@here&quot;</td>
 </tr>
 <!--Reply notification-->
 <tr>


### PR DESCRIPTION
As a result of PR 6372, at-here is now included by default in the list of words that cause mentions.