### PR TITLE
Remove Off-Topic verification

### DIFF
--- a/src/test/html/TeamSettingsNameDesc.html
+++ b/src/test/html/TeamSettingsNameDesc.html
@@ -51,11 +51,6 @@
 	<td>link=Town Square</td>
 	<td>Town Square</td>
 </tr>
-<tr>
-	<td>waitForElementPresent</td>
-	<td>link=Off-Topic</td>
-	<td></td>
-</tr>
 <!--Save team name with no changes-->
 <tr>
 	<td>waitForText</td>

--- a/src/test/java/com/mattermost/selenium/tests/TeamSettingsNameDescIT.java
+++ b/src/test/java/com/mattermost/selenium/tests/TeamSettingsNameDescIT.java
@@ -39,12 +39,6 @@ public class TeamSettingsNameDescIT extends DriverBase {
         	Thread.sleep(1000);
         }
 
-        for (int second = 0;; second++) {
-        	if (second >= 60) fail("timeout");
-        	try { if (isElementPresent(By.linkText("Off-Topic"))) break; } catch (Exception e) {}
-        	Thread.sleep(1000);
-        }
-
         // Save team name with no changes
         for (int second = 0;; second++) {
         	if (second >= 60) fail("timeout");


### PR DESCRIPTION
Not really needed, and likely failing due to previous tests (if there are unreads in the channel, the link isn't recognized without the unreads number at the end).