### PR TITLE
Updating verification of display in ES

### DIFF
--- a/src/test/html/AccountSettingsDisplay.html
+++ b/src/test/html/AccountSettingsDisplay.html
@@ -450,8 +450,8 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=a.channel-header__description.light &gt; span</td>
-	<td>Agregar una descripción del canal</td>
+	<td>css=h4 &gt; span</td>
+	<td>CANALES PÚBLICOS</td>
 </tr>
 <tr>
 	<td>click</td>

--- a/src/test/java/com/mattermost/selenium/tests/AccountSettingsDisplayIT.java
+++ b/src/test/java/com/mattermost/selenium/tests/AccountSettingsDisplayIT.java
@@ -315,7 +315,7 @@ public class AccountSettingsDisplayIT extends DriverBase {
         driver.navigate().refresh();
         for (int second = 0;; second++) {
         	if (second >= 60) fail("timeout");
-        	try { if ("Agregar una descripción del canal".equals(driver.findElement(By.cssSelector("a.channel-header__description.light > span")).getText())) break; } catch (Exception e) {}
+        	try { if ("CANALES PÚBLICOS".equals(driver.findElement(By.cssSelector("h4 > span")).getText())) break; } catch (Exception e) {}
         	Thread.sleep(1000);
         }
 


### PR DESCRIPTION
It's failing to find the channel header placeholder text now for some reason. Changing it to verify Public Channels label instead.