### PR TITLE
Add pause / sleep before refresh

### DIFF
--- a/src/test/html/AccountSettingsDisplay.html
+++ b/src/test/html/AccountSettingsDisplay.html
@@ -444,6 +444,14 @@
 	<td></td>
 </tr>
 <tr>
+	<td>pause</td>
+	<td>3000</td>
+	<td></td>
+</tr>
+<!--Sleep-->
+<!--Sleep-->
+<!--Sleep-->
+<tr>
 	<td>refreshAndWait</td>
 	<td></td>
 	<td></td>

--- a/src/test/java/com/mattermost/selenium/tests/AccountSettingsDisplayIT.java
+++ b/src/test/java/com/mattermost/selenium/tests/AccountSettingsDisplayIT.java
@@ -312,6 +312,9 @@ public class AccountSettingsDisplayIT extends DriverBase {
         }
 
         driver.findElement(By.id("saveSetting")).click();
+        // Sleep
+        // Sleep
+        // Sleep
         driver.navigate().refresh();
         for (int second = 0;; second++) {
         	if (second >= 60) fail("timeout");


### PR DESCRIPTION
For some reason, it's failing and the screenshot is a blank screen every time. Tried a different verification, but it's not even loading the page there to find anything to verify. Trying just adding a pause/sleep before the refresh in that part of the test to see if that helps. Haven't had this issue with this test or any other before.