### PR TITLE
Locking to 4.6.0-rc4

### DIFF
--- a/setup-for-run.sh
+++ b/setup-for-run.sh
@@ -12,8 +12,8 @@ rm -f mattermost.tar.gz
 # mv mattermost-enterprise-linux-amd64.tar.gz mattermost.tar.gz
 
 # Use this to lock to specific version
-wget https://releases.mattermost.com/4.6.0-rc3/mattermost-4.6.0-rc3-linux-amd64.tar.gz
-mv mattermost-4.6.0-rc3-linux-amd64.tar.gz mattermost.tar.gz
+wget https://releases.mattermost.com/4.6.0-rc4/mattermost-4.6.0-rc4-linux-amd64.tar.gz
+mv mattermost-4.6.0-rc4-linux-amd64.tar.gz mattermost.tar.gz
 
 
 rm -rf ~/mattermost


### PR DESCRIPTION
Locking to 4.6.0-rc4 to start running smoke tests for the final cut.