### PR TITLE
Add more APIv3 banner dismissals

### DIFF
--- a/src/test/html/ChannelSettingsPubHeader.html
+++ b/src/test/html/ChannelSettingsPubHeader.html
@@ -155,6 +155,32 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
+<!--Dismiss APIv3 deprecation banner-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Learn how to migrate to APIv4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=span &gt; span</td>
+	<td>API version 3 is deprecated and scheduled for removal. Learn how to migrate to APIv4.</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=×</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=×</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>link=Learn how to migrate to APIv4</td>
+	<td></td>
+</tr>
 <tr>
 	<td>waitForText</td>
 	<td>css=strong.heading</td>
@@ -293,6 +319,32 @@
 	<td>css=strong.heading</td>
 	<td>headertest</td>
 </tr>
+<!--Dismiss APIv3 deprecation banner-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Learn how to migrate to APIv4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=span &gt; span</td>
+	<td>API version 3 is deprecated and scheduled for removal. Learn how to migrate to APIv4.</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=×</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=×</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>link=Learn how to migrate to APIv4</td>
+	<td></td>
+</tr>
 <!--Add header using `Set a Header` link-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -391,6 +443,32 @@
 <tr>
 	<td>pause</td>
 	<td>1000</td>
+	<td></td>
+</tr>
+<!--Dismiss APIv3 deprecation banner-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Learn how to migrate to APIv4</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=span &gt; span</td>
+	<td>API version 3 is deprecated and scheduled for removal. Learn how to migrate to APIv4.</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=×</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=×</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>link=Learn how to migrate to APIv4</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/java/com/mattermost/selenium/tests/ChannelSettingsPubHeaderIT.java
+++ b/src/test/java/com/mattermost/selenium/tests/ChannelSettingsPubHeaderIT.java
@@ -127,6 +127,32 @@ public class ChannelSettingsPubHeaderIT extends DriverBase {
         // Sleep
         // Sleep
         // Sleep
+        // Dismiss APIv3 deprecation banner
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (isElementPresent(By.linkText("Learn how to migrate to APIv4"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if ("API version 3 is deprecated and scheduled for removal. Learn how to migrate to APIv4.".equals(driver.findElement(By.cssSelector("span > span")).getText())) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (isElementPresent(By.linkText("×"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        driver.findElement(By.linkText("×")).click();
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (!isElementPresent(By.linkText("Learn how to migrate to APIv4"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
         for (int second = 0;; second++) {
         	if (second >= 60) fail("timeout");
         	try { if ("headertest".equals(driver.findElement(By.cssSelector("strong.heading")).getText())) break; } catch (Exception e) {}
@@ -218,6 +244,32 @@ public class ChannelSettingsPubHeaderIT extends DriverBase {
         	Thread.sleep(1000);
         }
 
+        // Dismiss APIv3 deprecation banner
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (isElementPresent(By.linkText("Learn how to migrate to APIv4"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if ("API version 3 is deprecated and scheduled for removal. Learn how to migrate to APIv4.".equals(driver.findElement(By.cssSelector("span > span")).getText())) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (isElementPresent(By.linkText("×"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        driver.findElement(By.linkText("×")).click();
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (!isElementPresent(By.linkText("Learn how to migrate to APIv4"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
         // Add header using `Set a Header` link
         for (int second = 0;; second++) {
         	if (second >= 60) fail("timeout");
@@ -283,6 +335,32 @@ public class ChannelSettingsPubHeaderIT extends DriverBase {
         driver.navigate().refresh();
         // Edit header, use markdown
         // Sleep
+        // Dismiss APIv3 deprecation banner
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (isElementPresent(By.linkText("Learn how to migrate to APIv4"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if ("API version 3 is deprecated and scheduled for removal. Learn how to migrate to APIv4.".equals(driver.findElement(By.cssSelector("span > span")).getText())) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (isElementPresent(By.linkText("×"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
+        driver.findElement(By.linkText("×")).click();
+        for (int second = 0;; second++) {
+        	if (second >= 60) fail("timeout");
+        	try { if (!isElementPresent(By.linkText("Learn how to migrate to APIv4"))) break; } catch (Exception e) {}
+        	Thread.sleep(1000);
+        }
+
         for (int second = 0;; second++) {
         	if (second >= 60) fail("timeout");
         	try { if (isElementPresent(By.id("channelHeaderDropdownButton"))) break; } catch (Exception e) {}


### PR DESCRIPTION
Se can’t find the channel drop-down because of the APIv3 deprecation
banner. It may be rolled back, but in the meantime, adding a dismissal
of it after every refresh to see if that helps.