### PR TITLE
Update channel header IDs

### DIFF
--- a/src/test/html/ide-only/Channel/ChannelConvertPubToPrivate.html
+++ b/src/test/html/ide-only/Channel/ChannelConvertPubToPrivate.html
@@ -1305,7 +1305,7 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td>View Members</td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Channel/ChannelName.html
+++ b/src/test/html/ide-only/Channel/ChannelName.html
@@ -271,7 +271,7 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -854,7 +854,7 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -1115,7 +1115,7 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Channel/ChannelNotificationsUI.html
+++ b/src/test/html/ide-only/Channel/ChannelNotificationsUI.html
@@ -107,12 +107,12 @@
 <!--Verify modal elements-->
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -620,12 +620,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -731,12 +731,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -881,12 +881,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -1394,12 +1394,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -1505,12 +1505,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -1629,12 +1629,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -2142,12 +2142,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -2253,12 +2253,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -2423,12 +2423,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -2936,12 +2936,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -3047,12 +3047,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -3171,12 +3171,12 @@
 <!--Set team 1 to Never-->
 <tr>
 	<td>waitForText</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td>Notification Preferences</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -3267,12 +3267,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td>Notification Preferences</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -3358,12 +3358,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td>Notification Preferences</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>
@@ -3450,12 +3450,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td>Notification Preferences</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Permissions/PermissionSchemes-ComboScenarios.html
+++ b/src/test/html/ide-only/Permissions/PermissionSchemes-ComboScenarios.html
@@ -1567,12 +1567,12 @@
 <!--Go into the modal as user-->
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Smoke/ST.html
+++ b/src/test/html/ide-only/Smoke/ST.html
@@ -4479,7 +4479,7 @@
 </tr>
 <tr>
 	<td>verifyElementPresent</td>
-	<td>id=channelNotificationsGroup</td>
+	<td>id=channelNotifications</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/SystemConsole/scPolicy5ChanManagePri.html
+++ b/src/test/html/ide-only/SystemConsole/scPolicy5ChanManagePri.html
@@ -262,17 +262,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>id=channelAddMembers</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
@@ -396,17 +391,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>id=channelAddMembers</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
@@ -521,17 +511,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>id=channelAddMembers</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
@@ -794,11 +779,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelViewMembers</td>
-	<td></td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=channelAddMembers</td>
 	<td></td>
@@ -964,17 +944,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>id=channelAddMembers</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
@@ -1089,17 +1064,12 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>id=channelAddMembers</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <!--Member icon: View but not manage or add-->
@@ -1357,11 +1327,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelViewMembers</td>
-	<td></td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=channelAddMembers</td>
 	<td></td>
@@ -1487,11 +1452,6 @@
 </tr>
 <!--Verify channel admin can see Add and Manage Members on private channel-->
 <tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelViewMembers</td>
-	<td></td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=channelAddMembers</td>
 	<td></td>
@@ -1614,17 +1574,12 @@
 <!--Channel drop-down-->
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=channelViewMembers</td>
+	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>id=channelAddMembers</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelManageMembers</td>
 	<td></td>
 </tr>
 <!--Member icon: View but not manage or add-->
@@ -1883,11 +1838,6 @@
 </tr>
 <!--Drop-down: Add, Manage Members; Member icon: Manage Members-->
 <tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelViewMembers</td>
-	<td></td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=channelAddMembers</td>
 	<td></td>
@@ -2012,11 +1962,6 @@
 </tr>
 <!--Verify channel admin can see Add and Manage Members on private channel-->
 <tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelViewMembers</td>
-	<td></td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=channelAddMembers</td>
 	<td></td>
@@ -2136,11 +2081,6 @@
 </tr>
 <!--Verify non-admin member can see Add or Manage Members on private channel-->
 <!--Channel drop-down-->
-<tr>
-	<td>waitForElementNotPresent</td>
-	<td>id=channelViewMembers</td>
-	<td></td>
-</tr>
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=channelAddMembers</td>


### PR DESCRIPTION
PR on the webapp reverted all the channel header IDs except for the following:
- Changed `channelNotificationsGroup` into `channelNotifications`
- `channelManageMembers` and `channelViewMembers` are known as `channelManageMembers` only.  I didn't revert the distinction between these to not create major change  on the webapp.  So this PR update all those `channelViewMembers` either update or delete if not necessary.

Referenced Webapp PR - https://github.com/mattermost/mattermost-webapp/pull/2160