### PR TITLE
Updates to some System Console tests during 5.8 testing

### DIFF
--- a/src/test/html/ide-only/Auth/AuthAD_LDAP.html
+++ b/src/test/html/ide-only/Auth/AuthAD_LDAP.html
@@ -44,6 +44,17 @@
 	<td>id=LdapSettings.Enablefalse</td>
 	<td></td>
 </tr>
+<!--Ensure LDAP sync is enabled-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=LdapSettings.EnableSynctrue</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=LdapSettings.EnableSynctrue</td>
+	<td></td>
+</tr>
 <!--Store login placeholder text to put it back later-->
 <tr>
 	<td>storeText</td>
@@ -907,10 +918,20 @@
 	<td>4000</td>
 	<td></td>
 </tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
 <!--*** Manually click through 1) TOS 2) team select and 3) tutorial as needed-->
 <tr>
 	<td>pause</td>
 	<td>4000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=post_textbox</td>
 	<td></td>
 </tr>
 <tr>
@@ -1372,6 +1393,7 @@
 	<td></td>
 </tr>
 <!--Nickname not editable for LDAP account (w/attribute set in LDAP)-->
+<!--If didn't set nickname attribute, this will fail (it will be editable)-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=nicknameEdit</td>
@@ -1899,6 +1921,7 @@
 	<td>id=nameDesc</td>
 	<td>${firstlastldap}</td>
 </tr>
+<!--Nickname will fail if this attribute was never set-->
 <tr>
 	<td>waitForText</td>
 	<td>css=#nicknameDesc &gt; span</td>

--- a/src/test/html/ide-only/Channel/ChannelJoinLeave.html
+++ b/src/test/html/ide-only/Channel/ChannelJoinLeave.html
@@ -403,6 +403,11 @@
 	<td>Town Square</td>
 </tr>
 <tr>
+	<td>rollup</td>
+	<td>switchTeam</td>
+	<td>TeamName=ui-automation</td>
+</tr>
+<tr>
 	<td>waitForElementPresent</td>
 	<td>link=Off-Topic</td>
 	<td></td>
@@ -569,12 +574,12 @@
 <!--Cancel out of leaving-->
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/SystemConsole/scConfiguration.html
+++ b/src/test/html/ide-only/SystemConsole/scConfiguration.html
@@ -192,12 +192,12 @@
 <!--Cancel discarding changes-->
 <tr>
 	<td>waitForText</td>
-	<td>css=div.modal-footer &gt; button.btn.btn-default</td>
+	<td>css=button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=div.modal-footer &gt; button.btn.btn-default</td>
+	<td>css=button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
@@ -249,7 +249,7 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=a &gt; span</td>
+	<td>link=Site URL</td>
 	<td>Site URL</td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/SystemConsole/scLocalization.html
+++ b/src/test/html/ide-only/SystemConsole/scLocalization.html
@@ -2530,9 +2530,28 @@
 	<td>css=option[value=&quot;nl&quot;]</td>
 	<td></td>
 </tr>
-<!--Change defaults to something other than current language choice?-->
-<!--Wait to write test until decisions made about helpful error text, etc.-->
-<!--Set available languages back to all by removing selections-->
+<tr>
+	<td>waitForText</td>
+	<td>id=cancelSetting</td>
+	<td>Cancel</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=cancelSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.close</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.close</td>
+	<td></td>
+</tr>
+<!--- Switching to second available language after it is added-->
+<!--Set server and client and available to one language, JP-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>
@@ -2563,40 +2582,38 @@
 	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
 	<td></td>
 </tr>
+<!--Set default Server and Client to Japanese (JP)-->
 <tr>
-	<td>waitForText</td>
-	<td>css=div.Select-control</td>
-	<td>×Deutsch <br />×Español <br />×English</td>
+	<td>waitForElementPresent</td>
+	<td>id=LocalizationSettings.DefaultServerLocale</td>
+	<td></td>
 </tr>
 <tr>
-	<td>sendKeys</td>
-	<td>css=div.Select-control</td>
-	<td>${KEY_BACKSPACE}</td>
+	<td>select</td>
+	<td>id=LocalizationSettings.DefaultServerLocale</td>
+	<td>日本語</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=div.Select-control</td>
-	<td>×Deutsch <br />×Español</td>
+	<td>waitForElementPresent</td>
+	<td>id=LocalizationSettings.DefaultClientLocale</td>
+	<td></td>
 </tr>
 <tr>
-	<td>sendKeys</td>
-	<td>css=div.Select-control</td>
-	<td>${KEY_BACKSPACE}</td>
+	<td>select</td>
+	<td>id=LocalizationSettings.DefaultClientLocale</td>
+	<td>日本語</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=div.Select-control</td>
-	<td>×Deutsch</td>
+	<td>pause</td>
+	<td>8000</td>
+	<td></td>
 </tr>
+<!--*** Manually set Available to JP (the last one) and English-->
+<!--*** (Remove the other languages)-->
 <tr>
-	<td>sendKeys</td>
-	<td>css=div.Select-control</td>
-	<td>${KEY_BACKSPACE}</td>
-</tr>
-<tr>
-	<td>waitForText</td>
-	<td>css=div.Select-placeholder</td>
-	<td>Select...</td>
+	<td>waitForTextPresent</td>
+	<td>日本語<br /><br /><br />English</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -2613,9 +2630,9 @@
 	<td>id=saveSetting</td>
 	<td></td>
 </tr>
-<!--Log out-->
+<!--Set admin's client to Japanese-->
 <tr>
-	<td>waitForElementPresent</td>
+	<td>waitForText</td>
 	<td>css=span.dropdown__icon.admin-navbar-dropdown__icon</td>
 	<td></td>
 </tr>
@@ -2624,6 +2641,360 @@
 	<td>css=span.dropdown__icon.admin-navbar-dropdown__icon</td>
 	<td></td>
 </tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=displayButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=displayButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=languagesEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=languagesEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=displayLanguage</td>
+	<td></td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>id=displayLanguage</td>
+	<td>日本語</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#generalSettingsTitle &gt; span</td>
+	<td>全般の設定</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.close</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.close</td>
+	<td></td>
+</tr>
+<!--Remove English as available language-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>4000</td>
+	<td></td>
+</tr>
+<!--*** Manually click the X to remove English from Available-->
+<tr>
+	<td>waitForTextPresent</td>
+	<td>利用可能な言語:*日本語</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTextNotPresent</td>
+	<td>日本語<br /><br /><br />English</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<!--Verify Language is hidden in Account Settings-->
+<tr>
+	<td>click</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=displayButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=displayButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=channel_display_modeEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=languagesEdit</td>
+	<td></td>
+</tr>
+<!--Add English back as Available Language-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>4000</td>
+	<td></td>
+</tr>
+<!--*** Manually click the X to remove English from Available-->
+<tr>
+	<td>waitForTextPresent</td>
+	<td>利用可能な言語:*日本語*English</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<!--Switch to English in Account Settings-->
+<tr>
+	<td>click</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=displayButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=displayButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=languagesEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=languagesEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#settingTitle &gt; span</td>
+	<td>言語</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=displayLanguage</td>
+	<td></td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>id=displayLanguage</td>
+	<td>English</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#generalSettingsTitle &gt; span</td>
+	<td>General Settings</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.close</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.close</td>
+	<td></td>
+</tr>
+<!--Cleanup: Set defaults to English and clear Available Languages-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#localization &gt; span.sidebar-section.sidebar-subsection-title__text &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=LocalizationSettings.DefaultServerLocale</td>
+	<td></td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>id=LocalizationSettings.DefaultServerLocale</td>
+	<td>English</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=LocalizationSettings.DefaultClientLocale</td>
+	<td></td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>id=LocalizationSettings.DefaultClientLocale</td>
+	<td>English</td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>6000</td>
+	<td></td>
+</tr>
+<!--*** Manually click the Xs to remove EN and JP from Available-->
+<tr>
+	<td>waitForTextNotPresent</td>
+	<td>利用可能な言語:*日本語*English</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<!--Log out admin-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>css=#logout &gt; span</td>

--- a/src/test/html/ide-only/SystemConsole/scReporting.html
+++ b/src/test/html/ide-only/SystemConsole/scReporting.html
@@ -46,11 +46,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <!--Open System Console-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -228,7 +223,7 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>css=i.fa.fa-user</td>
+	<td>css=i.fa.fa-users</td>
 	<td></td>
 </tr>
 <tr>
@@ -519,7 +514,7 @@
 	<td>css=h4.modal-title &gt; span</td>
 	<td>About Mattermost</td>
 </tr>
-<!--The following two are failing; verify visually for now-->
+<!--About modal-->
 <tr>
 	<td>waitForText</td>
 	<td>css=div.form-group.less &gt; div &gt; span</td>
@@ -616,24 +611,6 @@
 	<td></td>
 </tr>
 <!--LOG OUT-->
-<tr>
-	<td>refreshAndWait</td>
-	<td></td>
-	<td></td>
-</tr>
-<tr>
-	<td>pause</td>
-	<td>3000</td>
-	<td></td>
-</tr>
-<!--Sleep-->
-<!--Sleep-->
-<!--Sleep-->
-<tr>
-	<td>click</td>
-	<td>id=adminNavbarDropdownButton</td>
-	<td></td>
-</tr>
 <tr>
 	<td>clickAndWait</td>
 	<td>css=#logout &gt; span</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersDeactivate.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersDeactivate.html
@@ -267,14 +267,14 @@
 	<td>exact:This action deactivates test2. They will be logged out and not have access to any teams or channels on this system. Are you sure you want to deactivate test2?</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>css=button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>waitForText</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersMgmt.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersMgmt.html
@@ -199,7 +199,7 @@
 <tr>
 	<td>sendKeys</td>
 	<td>id=searchUsers</td>
-	<td>${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}</td>
+	<td>${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}</td>
 </tr>
 <tr>
 	<td>waitForText</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersTeamsCreation.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersTeamsCreation.html
@@ -182,14 +182,14 @@
 	<td>User creation has been disabled for your team. Please ask your Team Administrator for details.</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=div.modal-invite-member.modal-dialog &gt; div.modal-content &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=div.modal-invite-member.modal-dialog &gt; div.modal-content &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <!--Error trying to use slash command /invite_people-->
 <tr>
@@ -511,13 +511,13 @@
 	<td>User creation has been disabled for your team. Please ask your Team Administrator for details.</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=div.modal-invite-member.modal-dialog &gt; div.modal-content &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=div.modal-invite-member.modal-dialog &gt; div.modal-content &gt; div.modal-footer &gt; button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <!--Team creation link visible to System Admin with text NOT visible ("This option is only available for System Administrators, and does not show up for other users.") Removed in MM-13429-->
@@ -582,7 +582,7 @@
 	<td>id=sidebarHeaderDropdownButton</td>
 	<td></td>
 </tr>
-<!--Team selection page displays team creation link and messaging-->
+<!--Team selection page displays team creation link-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>css=#joinAnotherTeam &gt; span</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersTeamsMaxes.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersTeamsMaxes.html
@@ -357,7 +357,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=label.control-label</td>
-	<td>This team has reached the maximum number of allowed accounts. Contact your systems administrator to set a higher limit.</td>
+	<td>This team has reached the maximum number of allowed accounts. Contact your System Administrator to set a higher limit.</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -927,7 +927,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=label.control-label</td>
-	<td>This team has reached the maximum number of allowed accounts. Contact your systems administrator to set a higher limit.</td>
+	<td>This team has reached the maximum number of allowed accounts. Contact your System Administrator to set a higher limit.</td>
 </tr>
 <tr>
 	<td>pause</td>
@@ -1201,9 +1201,14 @@
 	<td>Unable to create more than 5 channels for current team</td>
 </tr>
 <tr>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
+</tr>
+<tr>
 	<td>click</td>
-	<td>css=form.form-horizontal &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <!--Delete channel, still counts toward max and can't create new-->
 <tr>
@@ -1262,9 +1267,14 @@
 	<td>Unable to create more than 5 channels for current team</td>
 </tr>
 <tr>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
+</tr>
+<tr>
 	<td>click</td>
-	<td>css=form.form-horizontal &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <!--Open System Console-->
 <tr>
@@ -1855,13 +1865,13 @@
 <!--Cancel out of warning, message does not post-->
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td>Cancel</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForText</td>


### PR DESCRIPTION
- AuthAD_LDAP.html: Clarified LDAP sync setting and nickname attribute
- ChannelJoinLeave.html: Rollup for switching teams, Cancel button
changed locator
- scConfiguration.html: Cancel button changed locator
- scLocalization.html: A few tests added for MM-13680
- scReporting.html: Locator for table element changed
- scUsersDeactivate.html: Cancel button changed locator
- scUsersMgmt.html: Added missing backspaces
- scUsersTeamsCreation.html: Cancel button changed
- scUsersTeamsMaxes.html: Help text changed, Cancel button changed