### PR TITLE
Updates from 5.8 testing, new Email and GitLab tests

### DIFF
--- a/src/test/html/ide-only/AccountSettings/AccountSettingsEmail.html
+++ b/src/test/html/ide-only/AccountSettings/AccountSettingsEmail.html
@@ -1,0 +1,430 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://selenium.mattermost.com" />
+<title>AccountSettingsUsername</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">AccountSettingsUsername</td></tr>
+</thead><tbody>
+<tr>
+	<td>openAndWait</td>
+	<td>/login</td>
+	<td></td>
+</tr>
+<!--DisableAnimations-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=loginId</td>
+	<td>test@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>3000</td>
+	<td></td>
+</tr>
+<!--Sleep-->
+<!--Sleep-->
+<!--Sleep-->
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<!--General Settings-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=primaryEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>test-edit@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>test-edit@test.com</td>
+</tr>
+<!--Blank password error-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=clientError</td>
+	<td>Please enter your current password.</td>
+</tr>
+<!--Incorrect password error-->
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>lalalala</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=serverError</td>
+	<td>Your password is incorrect.</td>
+</tr>
+<!--Correct password entered, but Cancel, no change-->
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=cancelSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=cancelSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=emailDesc</td>
+	<td>test@test.com</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=usernameDesc</td>
+	<td>test</td>
+</tr>
+<!--Invalid email address-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=primaryEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>test-edit-test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>test-edit-test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=clientError</td>
+	<td>Please enter a valid email address</td>
+</tr>
+<!--Mismatched new and confirm emails-->
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>test-edit@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>test-edited@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=clientError</td>
+	<td>The new emails you entered do not match.</td>
+</tr>
+<!--Blank New Email-->
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>test-edited@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=clientError</td>
+	<td>Please enter a valid email address</td>
+</tr>
+<!--Blank Confirm Email-->
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>test-edit@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=clientError</td>
+	<td>The new emails you entered do not match.</td>
+</tr>
+<!--All blank-->
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=clientError</td>
+	<td>Please enter a valid email address</td>
+</tr>
+<!--Successfully change (this is on server without verification req)-->
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>test-edit@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>test-edit@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=emailDesc</td>
+	<td>test-edit@test.com</td>
+</tr>
+<!--Log out test-edit@test.com-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Cannot log in with old email address-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=loginId</td>
+	<td>test@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=label.control-label</td>
+	<td>We couldn't find an account matching your login credentials.</td>
+</tr>
+<!--Can log in with new email address-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=loginId</td>
+	<td>test-edit@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Cleanup: Set email address back to test@test.com-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=primaryEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>test@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>test@test.com</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=emailDesc</td>
+	<td>test@test.com</td>
+</tr>
+<!--Log out test@test.com-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+</tbody></table>
+</body>
+</html>

--- a/src/test/html/ide-only/Auth/AuthGitLab.html
+++ b/src/test/html/ide-only/Auth/AuthGitLab.html
@@ -1,0 +1,2095 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<head profile="http://selenium-ide.openqa.org/profiles/test-case">
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<link rel="selenium.base" href="http://selenium.mattermost.com/" />
+<title>AuthGitLab</title>
+</head>
+<body>
+<table cellpadding="1" cellspacing="1" border="1">
+<thead>
+<tr><td rowspan="1" colspan="3">AuthGitLab</td></tr>
+</thead><tbody>
+<!--This tests on rctesting using the QA test account-->
+<tr>
+	<td>open</td>
+	<td>https://rctesting.reddogsofwar.com</td>
+	<td></td>
+</tr>
+<!--Enter creds for any system admin (but don't click to log in)-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>8000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotValue</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotValue</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>storeValue</td>
+	<td>id=loginId</td>
+	<td>adminuser</td>
+</tr>
+<tr>
+	<td>storeValue</td>
+	<td>id=loginPassword</td>
+	<td>adminpassword</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Disable signups-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=users_and_teams</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=users_and_teams</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=TeamSettings.EnableUserCreationfalse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=TeamSettings.EnableUserCreationfalse</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<!--Log out system admin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=#signup &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#signup &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab Single Sign-On</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab Single Sign-On</td>
+	<td></td>
+</tr>
+<!--Error displays with signup disabled-->
+<tr>
+	<td>waitForText</td>
+	<td>css=p</td>
+	<td>User sign-up is disabled.</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=h2</td>
+	<td>Error</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Back to Mattermost</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Back to Mattermost</td>
+	<td></td>
+</tr>
+<!--Log in as system admin using previously stored creds-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginId</td>
+	<td>${adminuser}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginPassword</td>
+	<td>${adminpassword}</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Re-enable signups-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=users_and_teams</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=users_and_teams</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=TeamSettings.EnableUserCreationtrue</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=TeamSettings.EnableUserCreationtrue</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=span.dropdown__icon.admin-navbar-dropdown__icon</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=span.dropdown__icon.admin-navbar-dropdown__icon</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Switch to*</td>
+	<td></td>
+</tr>
+<!--Get team invite (for whichever team was top of the drop-down)-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=getTeamInviteLink</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=getTeamInviteLink</td>
+	<td></td>
+</tr>
+<tr>
+	<td>storeText</td>
+	<td>id=linkModalTextArea</td>
+	<td>teaminvite</td>
+</tr>
+<!--Log out system admin-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<!--Open team invite link-->
+<tr>
+	<td>open</td>
+	<td>${teaminvite}</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=strong &gt; span</td>
+	<td>Create an account with:</td>
+</tr>
+<!--Create account using QA test GitLab account-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab Single Sign-On</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab Single Sign-On</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=user_login</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=user_login</td>
+	<td>mmostqa</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=user_password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=user_password</td>
+	<td>passwdpasswd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=commit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>name=commit</td>
+	<td></td>
+</tr>
+<!--Note: First time through, clicked to Authorize the app-->
+<!--But shouldn't be asked that again unless they change TOS or something-->
+<!--Account is created and tutorial displays-->
+<tr>
+	<td>waitForText</td>
+	<td>id=tutorialIntroOne</td>
+	<td>Welcome to:MattermostYour team communication all in one place, instantly searchable and available anywhere.<br />Keep your team connected to help them achieve what matters most.</td>
+</tr>
+<!--Password can't be changed for GitLab signin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=securityButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=securityButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#passwordDesc &gt; span</td>
+	<td>Login done through GitLab</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=passwordEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=passwordEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTextPresent</td>
+	<td>Login occurs through GitLab. Password cannot be updated.</td>
+	<td></td>
+</tr>
+<!--Change signin method to email/password-->
+<tr>
+	<td>waitForText</td>
+	<td>css=#signinDesc &gt; span</td>
+	<td>GitLab</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=signinEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=signinEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Switch to using email and password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Switch to using email and password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=h3 &gt; span</td>
+	<td>Switch Gitlab SSO Account to Email</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=passwordconfirm</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=passwordconfirm</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-primary</td>
+	<td>Switch Gitlab SSO to email and password</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--Success message-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.alert.alert-success</td>
+	<td>Sign-in method changed successfully</td>
+</tr>
+<!--Can log in using email/password-->
+<tr>
+	<td>rollup</td>
+	<td>login</td>
+	<td>username=mmostqa</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<!--Log out mmostqa-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Fail to log in using the GitLab account that switched to email-->
+<!--Error message displays-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=p</td>
+	<td>There is already an account associated with that email address using a sign in method other than gitlab. Please sign in using email.</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=h2</td>
+	<td>Error</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Back to Mattermost</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Back to Mattermost</td>
+	<td></td>
+</tr>
+<!--Switch email/password signin to GitLab-->
+<tr>
+	<td>rollup</td>
+	<td>login</td>
+	<td>username=mmostqa</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=securityButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=securityButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#signinDesc &gt; span</td>
+	<td>Email and Password</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=signinEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=signinEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Switch to using GitLab SSO</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Switch to using GitLab SSO</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-primary</td>
+	<td>Switch account to Gitlab SSO</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--Success message-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.alert.alert-success</td>
+	<td>Sign-in method changed successfully</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<!--Signs in successfully using GitLab-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<!--Verify username and email can't be edited because set in GitLab-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=usernameEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=usernameEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.setting-list__hint &gt; span &gt; span</td>
+	<td>This field is handled through your login provider. If you want to change it, you need to do so through your login provider.</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#emailDesc &gt; span</td>
+	<td>Login done through GitLab (mmostqa@gmail.com)</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<!--Won't fix: Text alignment not ideal-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.setting-list__hint.col-sm-12 &gt; span</td>
+	<td>Login occurs through GitLab. Email cannot be updated. Email address used for notifications is mmostqa@gmail.com.</td>
+</tr>
+<!--Edit first and last name-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=nameEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=nameEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=firstName</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=firstName</td>
+	<td>QA-edit</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=lastName</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=lastName</td>
+	<td>Reddogs-edit</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=nameDesc</td>
+	<td>QA-edit Reddogs-edit</td>
+</tr>
+<!--Log out mmostqa-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Open GitLab-->
+<tr>
+	<td>open</td>
+	<td>https://gitlab.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<!--Edit email address in Profile-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Profile</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Profile</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=i.fa.fa-pencil</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=i.fa.fa-pencil</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=user_email</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=user_email</td>
+	<td>mmostqa+edit@gmail.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=commit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>name=commit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=user_email</td>
+	<td>mmostqa+edit@gmail.com</td>
+</tr>
+<!--Store full name value-->
+<tr>
+	<td>storeValue</td>
+	<td>id=user_name</td>
+	<td>gitlabfullname</td>
+</tr>
+<!--Edit username in Account-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Account</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Account</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=username-change-input</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=username-change-input</td>
+	<td>-edit</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-warning</td>
+	<td>Update username</td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>css=button.btn.btn-warning</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-warning</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.js-modal-primary-action.qa-modal-primary-button.btn-warning</td>
+	<td>Update username</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.js-modal-primary-action.qa-modal-primary-button.btn-warning</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=username-change-input</td>
+	<td>mmostqa-edit</td>
+</tr>
+<!--Back to Mattermost, sign in using GitLab-->
+<tr>
+	<td>open</td>
+	<td>https://rctesting.reddogsofwar.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<!--Username updated to what was edited in GitLab-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div#headerUsername.user__name</td>
+	<td>@mmostqa-edit</td>
+</tr>
+<!--Full name matches GitLab (replacing previous edit in Mm)-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=nameDesc</td>
+	<td>${gitlabfullname}</td>
+</tr>
+<!--Username matches GitLab here as well-->
+<tr>
+	<td>waitForText</td>
+	<td>id=usernameDesc</td>
+	<td>mmostqa-edit</td>
+</tr>
+<!--Email not updated until verified-->
+<tr>
+	<td>waitForText</td>
+	<td>id=emailDesc</td>
+	<td>Login done through GitLab (mmostqa@gmail.com)</td>
+</tr>
+<!--Log out mmostqa-edit-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Open Gmail to verify new email address-->
+<tr>
+	<td>open</td>
+	<td>https://gmail.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Sign In</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Sign In</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=identifierId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=identifierId</td>
+	<td>mmostqa</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=identifierId</td>
+	<td>${KEY_ENTER}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwdpasswd</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>name=password</td>
+	<td>${KEY_ENTER}</td>
+</tr>
+<tr>
+	<td>verifyElementPresent</td>
+	<td>css=span:contains('Confirmation instructions')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=span:contains('Confirmation instructions')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=mmostqa+edit@gmail.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Confirm your email address</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Confirm your email address</td>
+	<td></td>
+</tr>
+<tr>
+	<td>selectPopUp</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>close</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>selectWindow</td>
+	<td>null</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.container-fluid.container-limited&nbsp;&nbsp;&nbsp;&gt; span</td>
+	<td>Your email address has been successfully confirmed.</td>
+</tr>
+<!--Back to Mattermost-->
+<tr>
+	<td>open</td>
+	<td>https://rctesting.reddogsofwar.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<!--Email address has updated after verification-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#emailDesc &gt; span</td>
+	<td>Login done through GitLab (mmostqa+edit@gmail.com)</td>
+</tr>
+<!--Log out mmostqa-edit-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Log in system admin using previously stored credentials-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginId</td>
+	<td>${adminuser}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginPassword</td>
+	<td>${adminpassword}</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Deactivate GitLab user-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=users</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=users</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=searchUsers</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=searchUsers</td>
+	<td>mmostqa</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.more-modal__name &gt; span</td>
+	<td>@mmostqa-edit - QA Reddogs</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#memberDropdown &gt; span &gt; span</td>
+	<td>Member</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=#memberDropdown &gt; span &gt; span</td>
+	<td>Member</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=deactivate</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=deactivate</td>
+	<td></td>
+</tr>
+<!--Verify SSO messaging-->
+<tr>
+	<td>waitForText</td>
+	<td>css=strong &gt; span</td>
+	<td>You must also deactivate this user in the SSO provider or they will be reactivated on next login or sync.</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-danger</td>
+	<td>Deactivate</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-danger</td>
+	<td>Deactivate</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#memberDropdown &gt; span &gt; span</td>
+	<td>Inactive</td>
+</tr>
+<!--Log out system admin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<!--GitLab user is reactivated on signing in using SSO-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div#headerUsername.user__name</td>
+	<td>@mmostqa-edit</td>
+</tr>
+<!--Log out mmostqa-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Log in system admin using previously stored credentials-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginId</td>
+	<td>${adminuser}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginPassword</td>
+	<td>${adminpassword}</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Deactivate GitLab user-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<!--Fields hide when GitLab signin is disabled-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=oauth</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=oauth</td>
+	<td></td>
+</tr>
+<!--Note: rctesting is set up with dual OAuth; first change to GitLab-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=oauthType</td>
+	<td></td>
+</tr>
+<tr>
+	<td>select</td>
+	<td>id=oauthType</td>
+	<td>label=GitLab</td>
+</tr>
+<tr>
+	<td>storeValue</td>
+	<td>id=GitLabSettings.Id</td>
+	<td>gitlabappid</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=GitLabSettings.Url</td>
+	<td>exact:https://gitlab.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<!--Disable OAuth signin; fields are hidden-->
+<tr>
+	<td>select</td>
+	<td>id=oauthType</td>
+	<td>label=Do not allow sign-in via an OAuth 2.0 provider</td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Id</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Url</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>refreshAndWait</td>
+	<td></td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=oauthType</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Id</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Url</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<!--Set back to GitLab; fields are displayed with previous values-->
+<tr>
+	<td>select</td>
+	<td>id=oauthType</td>
+	<td>label=GitLab</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=GitLabSettings.Id</td>
+	<td>${gitlabappid}</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=GitLabSettings.Url</td>
+	<td>exact:https://gitlab.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=GitLabSettings.Secret</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>refreshAndWait</td>
+	<td></td>
+	<td></td>
+</tr>
+<!--Endpoint values pre-populate based on GitLab Site URL-->
+<!-- and are uneditable-->
+<tr>
+	<td>storeValue</td>
+	<td>id=GitLabSettings.Url</td>
+	<td>gitlaburl</td>
+</tr>
+<tr>
+	<td>verifyValue</td>
+	<td>id=GitLabSettings.UserApiEndpoint</td>
+	<td>${gitlaburl}/api/v4/user</td>
+</tr>
+<tr>
+	<td>verifyValue</td>
+	<td>id=GitLabSettings.AuthEndpoint</td>
+	<td>${gitlaburl}/oauth/authorize</td>
+</tr>
+<tr>
+	<td>verifyValue</td>
+	<td>id=GitLabSettings.TokenEndpoint</td>
+	<td>${gitlaburl}/oauth/token</td>
+</tr>
+<tr>
+	<td>verifyNotEditable</td>
+	<td>id=GitLabSettings.UserApiEndpoint</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNotEditable</td>
+	<td>id=GitLabSettings.AuthEndpoint</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyNotEditable</td>
+	<td>id=GitLabSettings.TokenEndpoint</td>
+	<td></td>
+</tr>
+<!--Changing GitLab Site URL auto-changes endpoint values-->
+<tr>
+	<td>type</td>
+	<td>id=GitLabSettings.Url</td>
+	<td>http://example.com</td>
+</tr>
+<tr>
+	<td>verifyValue</td>
+	<td>id=GitLabSettings.UserApiEndpoint</td>
+	<td>http://example.com/api/v4/user</td>
+</tr>
+<tr>
+	<td>verifyValue</td>
+	<td>id=GitLabSettings.AuthEndpoint</td>
+	<td>http://example.com/oauth/authorize</td>
+</tr>
+<tr>
+	<td>verifyValue</td>
+	<td>id=GitLabSettings.TokenEndpoint</td>
+	<td>http://example.com/oauth/token</td>
+</tr>
+<!--Discard changes-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=configuration</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=configuration</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-primary</td>
+	<td>Yes, Discard</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--Removing Mattermost Site URL does not prevent GitLab signin-->
+<tr>
+	<td>storeValue</td>
+	<td>id=ServiceSettings.SiteURL</td>
+	<td>mmsiteurl</td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=ServiceSettings.SiteURL</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=p.markdown__paragraph-inline</td>
+	<td>Please configure your Site URL in the System Console or in gitlab.rb if you're using GitLab Mattermost.</td>
+</tr>
+<!--Log out system admin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<!--GitLab user can still sign in-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div#headerUsername.user__name</td>
+	<td>@mmostqa-edit</td>
+</tr>
+<!--Log out mmostqa-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Log in system admin using previously stored credentials-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginId</td>
+	<td>${adminuser}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=loginPassword</td>
+	<td>${adminpassword}</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Re-enter Site URL-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=configuration</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=configuration</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=ServiceSettings.SiteURL</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=ServiceSettings.SiteURL</td>
+	<td>${mmsiteurl}</td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotText</td>
+	<td>css=p.markdown__paragraph-inline</td>
+	<td>Please configure your Site URL in the System Console or in gitlab.rb if you're using GitLab Mattermost.</td>
+</tr>
+<!--Log out system admin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<!--Verify messaging when Mattermost is not authorised-->
+<!--Open GitLab and de-authorize Mattermost-->
+<tr>
+	<td>open</td>
+	<td>https://gitlab.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Settings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Settings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Applications</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Applications</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=td</td>
+	<td>MattermostTest</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>css=form &gt; input[name=&quot;commit&quot;]</td>
+	<td>Revoke</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=form &gt; input[name=&quot;commit&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotText</td>
+	<td>css=td</td>
+	<td>MattermostTest</td>
+</tr>
+<!--Back to Mattermost-->
+<tr>
+	<td>open</td>
+	<td>https://rctesting.reddogsofwar.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<!--Authorization page displays-->
+<tr>
+	<td>waitForText</td>
+	<td>css=h3.page-title</td>
+	<td>exact:Authorize MattermostTest to use your account?</td>
+</tr>
+<!--Denying authorization prevents login-->
+<tr>
+	<td>waitForValue</td>
+	<td>name=commit</td>
+	<td>Deny</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>name=commit</td>
+	<td>Deny</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=span</td>
+	<td>Authorization Error</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=p &gt; span</td>
+	<td>You must authorize Mattermost to log in with Gitlab.</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=a &gt; span</td>
+	<td>Back to login page</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=a &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=GitLab</td>
+	<td></td>
+</tr>
+<!--Authorization page displays-->
+<tr>
+	<td>waitForText</td>
+	<td>css=h3.page-title</td>
+	<td>exact:Authorize MattermostTest to use your account?</td>
+</tr>
+<!--Authorizing allows login-->
+<tr>
+	<td>clickAndWait</td>
+	<td>xpath=(//input[@name='commit'])[2]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div#headerUsername.user__name</td>
+	<td>@mmostqa-edit</td>
+</tr>
+<!--Cleanup in Mattermost-->
+<!--Change signin method to email/password-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=securityButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=securityButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#signinDesc &gt; span</td>
+	<td>GitLab</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=signinEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=signinEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Switch to using email and password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Switch to using email and password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=h3 &gt; span</td>
+	<td>Switch Gitlab SSO Account to Email</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=password</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=password</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=passwordconfirm</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>name=passwordconfirm</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-primary</td>
+	<td>Switch Gitlab SSO to email and password</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--Success message-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.alert.alert-success</td>
+	<td>Sign-in method changed successfully</td>
+</tr>
+<!--Log in mmostqa-edit using email/password-->
+<tr>
+	<td>rollup</td>
+	<td>login</td>
+	<td>username=mmostqa-edit</td>
+</tr>
+<!--Change username and email address-->
+<!--Store timestamp to make username/email unique-->
+<tr>
+	<td>store</td>
+	<td>javascript{(new Date().getFullYear()+&quot;&quot;+(new Date().getMonth()+1)+&quot;&quot;+new Date().getDate())}</td>
+	<td>date</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=usernameEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=usernameEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=username</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=username</td>
+	<td>mmqa-${date}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=usernameDesc</td>
+	<td>mmqa-${date}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=primaryEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=primaryEmail</td>
+	<td>mmostqa+qa-${date}@mattermost.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=confirmEmail</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=confirmEmail</td>
+	<td>mmostqa+qa-${date}@mattermost.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#emailDesc &gt; span</td>
+	<td>Check your email to verify mmostqa+qa-${date}@mattermost.com</td>
+</tr>
+<!--Log out-->
+<tr>
+	<td>rollup</td>
+	<td>logout</td>
+	<td></td>
+</tr>
+<!--Cleanup in GitLab-->
+<tr>
+	<td>open</td>
+	<td>https://gitlab.com</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<!--Edit email address in Profile-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Profile</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Profile</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=i.fa.fa-pencil</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=i.fa.fa-pencil</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=user_email</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=user_email</td>
+	<td>mmostqa@gmail.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>name=commit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>name=commit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=user_email</td>
+	<td>mmostqa@gmail.com</td>
+</tr>
+<!--Edit username in Account-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Account</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Account</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=username-change-input</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=username-change-input</td>
+	<td>${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}${KEY_BACKSPACE}</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-warning</td>
+	<td>Update username</td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>css=button.btn.btn-warning</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-warning</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.js-modal-primary-action.qa-modal-primary-button.btn-warning</td>
+	<td>Update username</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.js-modal-primary-action.qa-modal-primary-button.btn-warning</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=username-change-input</td>
+	<td>mmostqa</td>
+</tr>
+<!--Log out of GitLab-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=a.header-user-dropdown-toggle</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Sign out</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Sign out</td>
+	<td></td>
+</tr>
+
+</tbody></table>
+</body>
+</html>

--- a/src/test/html/ide-only/Auth/AuthSAML.html
+++ b/src/test/html/ide-only/Auth/AuthSAML.html
@@ -47,9 +47,9 @@
 	<td>8000</td>
 	<td></td>
 </tr>
-<!--*** Manually enter valid OneLogin password for the test user-->
+<!--*** Manually enter valid OneLogin password for the test user (don't click to log in)-->
 <tr>
-	<td>waitForNotText</td>
+	<td>waitForNotValue</td>
 	<td>id=user_password</td>
 	<td></td>
 </tr>
@@ -138,7 +138,14 @@
 <tr>
 	<td>waitForText</td>
 	<td>id=nameDesc</td>
-	<td>QA Jesús Jes&amp;#xFA; OneLogin</td>
+	<td>QA Jesús*OneLogin</td>
+</tr>
+<!--This is supposed to verify literal `Jes&#xFA;` appears but-->
+<!--the command keeps converting it even if I try to escape it....-->
+<tr>
+	<td>waitForTextPresent</td>
+	<td>Jesú</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -1464,7 +1471,14 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=span.light</td>
-	<td>QA Jesús Jes&amp;#xFA; OneLogin</td>
+	<td>QA Jesús* OneLogin</td>
+</tr>
+<!--This is supposed to verify literal `Jes&#xFA;` appears but-->
+<!--the command keeps converting it even if I try to escape it....-->
+<tr>
+	<td>waitForTextPresent</td>
+	<td>Jesú</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForText</td>
@@ -1741,6 +1755,12 @@
 	<td>xpath=(//a[@id='createTeam'])[2]</td>
 	<td></td>
 </tr>
+<!--Store timestamp to append to team name (to make it unique)-->
+<tr>
+	<td>store</td>
+	<td>javascript{(new Date().getHours()+&quot;&quot; + new Date().getMinutes() + &quot;&quot; + new Date().getSeconds())}</td>
+	<td>time</td>
+</tr>
 <tr>
 	<td>waitForElementPresent</td>
 	<td>css=input.form-control</td>
@@ -1749,7 +1769,7 @@
 <tr>
 	<td>type</td>
 	<td>css=input.form-control</td>
-	<td>RCOpenSAML</td>
+	<td>OpenSAML-${time}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -1774,7 +1794,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=h1#headerTeamName.team__name</td>
-	<td>RCOpenSAML</td>
+	<td>OpenSAML-${time}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -1941,7 +1961,7 @@
 </tr>
 <!--*** Manually enter valid OKTA password for the test user-->
 <tr>
-	<td>waitForNotText</td>
+	<td>waitForNotValue</td>
 	<td>id=okta-signin-password</td>
 	<td></td>
 </tr>
@@ -2025,7 +2045,14 @@
 <tr>
 	<td>waitForText</td>
 	<td>id=nameDesc</td>
-	<td>QA Jesús Jes&amp;#xFA; OKTA</td>
+	<td>QA Jesús * OKTA</td>
+</tr>
+<!--This is supposed to verify literal `Jes&#xFA;` appears but-->
+<!--the command keeps converting it even if I try to escape it....-->
+<tr>
+	<td>waitForTextPresent</td>
+	<td>Jesú</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -2123,7 +2150,7 @@
 <tr>
 	<td>type</td>
 	<td>css=input.form-control</td>
-	<td>RCClosedSAML</td>
+	<td>ClsdSAML-${time}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -2148,7 +2175,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=h1#headerTeamName.team__name</td>
-	<td>RCClosedSAML</td>
+	<td>ClsdSAML-${time}</td>
 </tr>
 <!--Get team invite-->
 <tr>
@@ -2238,7 +2265,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=h1#headerTeamName.team__name</td>
-	<td>RCClosedSAML</td>
+	<td>ClsdSAML-${time}</td>
 </tr>
 <!--Switch OKTA to email: password mismatch error-->
 <tr>

--- a/src/test/html/ide-only/Channel/ChannelConvertPubToPrivate.html
+++ b/src/test/html/ide-only/Channel/ChannelConvertPubToPrivate.html
@@ -696,12 +696,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>No, cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Channel/ChannelNotificationsUI.html
+++ b/src/test/html/ide-only/Channel/ChannelNotificationsUI.html
@@ -596,7 +596,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For all activity, shown for 5 seconds</td>
+	<td>For all activity</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -808,7 +808,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For mentions and direct messages, shown for 5 seconds</td>
+	<td>For mentions and direct messages</td>
 </tr>
 <tr>
 	<td>refreshAndWait</td>
@@ -1360,7 +1360,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For all activity, shown for 5 seconds</td>
+	<td>For all activity</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -1587,7 +1587,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For mentions and direct messages, shown for 5 seconds</td>
+	<td>For mentions and direct messages</td>
 </tr>
 <tr>
 	<td>refreshAndWait</td>
@@ -2119,7 +2119,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For all activity, shown for 5 seconds</td>
+	<td>For all activity</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -2346,7 +2346,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For mentions and direct messages, shown for 5 seconds</td>
+	<td>For mentions and direct messages</td>
 </tr>
 <tr>
 	<td>refreshAndWait</td>
@@ -2923,7 +2923,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For all activity, shown for 5 seconds</td>
+	<td>For all activity</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -3145,7 +3145,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For mentions and direct messages, shown for 5 seconds</td>
+	<td>For mentions and direct messages</td>
 </tr>
 <!--(No notification preferences to test on DM channels)-->
 <!--Changing prefs on one Town Square doesn't change other team's Town Square-->

--- a/src/test/html/ide-only/Channel/ChannelSettingsPriHeader.html
+++ b/src/test/html/ide-only/Channel/ChannelSettingsPriHeader.html
@@ -216,12 +216,12 @@
 <!--Cancel-->
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default.cancel-button</td>
+	<td>css=button.btn.btn-link.cancel-button</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default.cancel-button</td>
+	<td>css=button.btn.btn-link.cancel-button</td>
 	<td>Cancel</td>
 </tr>
 <tr>
@@ -538,12 +538,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default.cancel-button</td>
+	<td>css=button.btn.btn-link.cancel-button</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default.cancel-button</td>
+	<td>css=button.btn.btn-link.cancel-button</td>
 	<td>Cancel</td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Channel/ChannelSettingsPurpose.html
+++ b/src/test/html/ide-only/Channel/ChannelSettingsPurpose.html
@@ -106,14 +106,14 @@
 </tr>
 <!--Cancel, no channel created-->
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=form.form-horizontal &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=form.form-horizontal &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <!--Create Public Channel through More... modal-->
 <tr>
@@ -557,14 +557,14 @@
 </tr>
 <!--Cancel, no channel created-->
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=form.form-horizontal &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=form.form-horizontal &gt; div.modal-footer &gt; button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <!--Create Private Channel through + icon-->
 <tr>

--- a/src/test/html/ide-only/EmailVerify/EmailVerifyMan.html
+++ b/src/test/html/ide-only/EmailVerify/EmailVerifyMan.html
@@ -16,12 +16,43 @@
 <!--*** Such as ci-linux-postgres-->
 <!--*** Replace target "**REPLACE-PREFIX**" below with your Mattermost -->
 <!--*** email prefix (e.g. `linda` or `linda+test`)-->
-<!--*** Log in to any server using that Mattermost email address-->
+<!--*** Enter the creds for that user but DON'T CLICK TO LOG IN-->
 <!--*** Then run tests and verify as described-->
 <tr>
 	<td>store</td>
 	<td>**REPLACE-PREFIX**</td>
 	<td>prefix</td>
+</tr>
+<!--*** Manually enter user credentials but DO NOT CLICK to log in-->
+<tr>
+	<td>waitForNotValue</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotValue</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>6000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>storeValue</td>
+	<td>id=loginId</td>
+	<td>username</td>
+</tr>
+<tr>
+	<td>storeValue</td>
+	<td>id=loginPassword</td>
+	<td>password</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
 </tr>
 <!--1. Change email address-->
 <tr>
@@ -73,6 +104,16 @@
 	<td>type</td>
 	<td>id=confirmEmail</td>
 	<td>${prefix}+verification@mattermost.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>${password}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -214,25 +255,9 @@
 	<td></td>
 </tr>
 <tr>
-	<td>pause</td>
-	<td>7000</td>
-	<td></td>
-</tr>
-<!--*** Manually type current password in Current Password field-->
-<tr>
-	<td>waitForNotValue</td>
+	<td>type</td>
 	<td>id=currentPassword</td>
-	<td></td>
-</tr>
-<tr>
-	<td>pause</td>
-	<td>7000</td>
-	<td></td>
-</tr>
-<tr>
-	<td>storeValue</td>
-	<td>id=currentPassword</td>
-	<td>key</td>
+	<td>${password}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -242,7 +267,7 @@
 <tr>
 	<td>type</td>
 	<td>id=newPassword</td>
-	<td>${key}</td>
+	<td>${password}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -252,7 +277,7 @@
 <tr>
 	<td>type</td>
 	<td>id=confirmPassword</td>
-	<td>${key}</td>
+	<td>${password}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -319,7 +344,7 @@
 <tr>
 	<td>type</td>
 	<td>id=loginPassword</td>
-	<td>${key}</td>
+	<td>${password}</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -372,6 +397,7 @@
 <!--2. Lists correct server name in body of email-->
 <!--*** MANUALLY CLEAN UP:-->
 <!--*** Replace your email address in first command in this test with **REPLACE-PREFIX**-->
+<!--***So it looks like this: store | **REPLACE-PREFIX** | prefix-->
 <!--*** And save, to be ready for next tester (or just don't save the change at all if other changes weren't made)-->
 <!--*** If you like, go back in and re-change your email address to what it had been-->
 </tbody></table>

--- a/src/test/html/ide-only/Experimental/channelSidebar.html
+++ b/src/test/html/ide-only/Experimental/channelSidebar.html
@@ -5374,12 +5374,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <!--More... below combined channel list-->
@@ -5568,12 +5568,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <!--More... below combined channel list-->

--- a/src/test/html/ide-only/Integrations/IntegrationsSlashCmds.html
+++ b/src/test/html/ide-only/Integrations/IntegrationsSlashCmds.html
@@ -278,13 +278,13 @@
 </tr>
 <!--Select "No, keep it as "Offline"-->
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default &gt; span:contains('No, keep it as &quot;Offline&quot;')</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>No, keep it as &quot;Offline&quot;</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default &gt; span:contains('No, keep it as &quot;Offline&quot;')</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/KeyShortcuts/KeyShortcutsUp.html
+++ b/src/test/html/ide-only/KeyShortcuts/KeyShortcutsUp.html
@@ -239,13 +239,13 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td>Cancel</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td></td>
 </tr>
 <!--Ephemeral message does not open for edit; opens previous regular message-->
 <tr>
@@ -274,9 +274,14 @@
 	<td>exact:Edit this one, okay?</td>
 </tr>
 <tr>
-	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td></td>
 </tr>
 <tr>
 	<td>refreshAndWait</td>
@@ -315,9 +320,14 @@
 	<td>exact:Edit this one, okay?</td>
 </tr>
 <tr>
-	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td></td>
 </tr>
 <!--LOG OUT test4-->
 <tr>
@@ -554,13 +564,13 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td>Cancel</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td></td>
 </tr>
 <!--Post code block, press UP, edit text-->
 <tr>

--- a/src/test/html/ide-only/Messaging/MessagingBasics.html
+++ b/src/test/html/ide-only/Messaging/MessagingBasics.html
@@ -337,13 +337,13 @@
 	<td>Hello. Cancel out of this edit</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>
@@ -742,12 +742,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>
@@ -1467,6 +1467,16 @@
 	<td>type</td>
 	<td>id=confirmEmail</td>
 	<td>changed@test.com</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -3355,6 +3365,16 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
 	<td>id=saveSetting</td>
 	<td></td>
 </tr>
@@ -3570,13 +3590,13 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default &gt; span:contains('Close')</td>
-	<td>Close</td>
+	<td>id=linkModalCloseButton</td>
+	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default &gt; span:contains('Close')</td>
-	<td>Close</td>
+	<td>id=linkModalCloseButton</td>
+	<td></td>
 </tr>
 <!--Leave Test- channel-->
 <tr>
@@ -3789,13 +3809,13 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default &gt; span:contains('Close')</td>
-	<td>Close</td>
+	<td>id=linkModalCloseButton</td>
+	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default &gt; span:contains('Close')</td>
-	<td>Close</td>
+	<td>id=linkModalCloseButton</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
@@ -3912,13 +3932,13 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default &gt; span:contains('Close')</td>
-	<td>Close</td>
+	<td>id=linkModalCloseButton</td>
+	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default &gt; span:contains('Close')</td>
-	<td>Close</td>
+	<td>id=linkModalCloseButton</td>
+	<td></td>
 </tr>
 <!--Log out-->
 <tr>
@@ -4003,7 +4023,7 @@
 	<td>link=Click here to jump to recent messages.</td>
 	<td>Click here to jump to recent messages.</td>
 </tr>
-<!--Verify propwer error page whan a user hit a permalink to a DM-->
+<!--Verify proper error page whan a user hit a permalink to a DM-->
 <tr>
 	<td>verifyText</td>
 	<td>id=moreDirectMessage</td>

--- a/src/test/html/ide-only/Messaging/MessagingEdit.html
+++ b/src/test/html/ide-only/Messaging/MessagingEdit.html
@@ -191,17 +191,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
-</tr>
-<tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>

--- a/src/test/html/ide-only/Messaging/MessagingEmojiCustomMan.html
+++ b/src/test/html/ide-only/Messaging/MessagingEmojiCustomMan.html
@@ -131,17 +131,17 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=form.form-horizontal</td>
-	<td>NameChoose a name for your emoji made of up to 64 characters consisting of lowercase letters, numbers, and the symbols '-' and '_'.<br /><br /><br />ImageSelect<br />JPG.jpgChoose the image for your emoji. The image can be a gif, png, or jpeg file with a max size of 1 MB. Dimensions will automatically resize to fit 128 by 128 pixels but keeping aspect ratio.<br /><br /><br /><br />PreviewThis is a sentence with in it.<br /><br />CancelSave</td>
+	<td>css=div.form__help &gt; span</td>
+	<td>Choose a name for your emoji made of up to 64 characters consisting of lowercase letters, numbers, and the symbols '-' and '_'.</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=div.col-md-5.col-sm-8 &gt; div &gt; div.form__help &gt; span</td>
-	<td>Choose the image for your emoji. The image can be a gif, png, or jpeg file with a max size of 1 MB. Dimensions will automatically resize to fit 128 by 128 pixels but keeping aspect ratio.</td>
+	<td>waitForElementPresent</td>
+	<td>link=Cancel</td>
+	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=a.btn.btn-sm &gt; span</td>
+	<td>link=Cancel</td>
 	<td></td>
 </tr>
 <tr>
@@ -829,7 +829,7 @@
 	<td>id=swithToui-automation</td>
 	<td></td>
 </tr>
-<!--Verify that custom emokis now render as text-->
+<!--Verify that custom emoji now render as text-->
 <tr>
 	<td>waitForText</td>
 	<td>css=span.all-emoji &gt; p &gt; span</td>
@@ -1012,7 +1012,7 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
@@ -2064,11 +2064,6 @@
 	<td>exact:This action permanently deletes the custom emoji. Are you sure you want to delete it?</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
-	<td>Cancel</td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>css=div.modal-footer &gt; button.btn.btn-primary</td>
 	<td></td>
@@ -2130,18 +2125,8 @@
 	<td>People</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>id=sidebarHeaderDropdownButton</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementPresent</td>
-	<td>link=System Console</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementPresent</td>
-	<td>id=ServiceSettings.EnableCustomEmojifalse</td>
+	<td>rollup</td>
+	<td>logout</td>
 	<td></td>
 </tr>
 </tbody></table>

--- a/src/test/html/ide-only/Messaging/MessagingMan.html
+++ b/src/test/html/ide-only/Messaging/MessagingMan.html
@@ -46,11 +46,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <!--Turn on link previews in System Console-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -479,19 +474,14 @@
 	<td></td>
 </tr>
 <tr>
-	<td>verifyText</td>
-	<td>css=div.modal-footer &gt; button.btn.btn-default &gt; span</td>
-	<td>Cancel</td>
-</tr>
-<tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>waitForElementNotPresent</td>
@@ -879,6 +869,7 @@
 </tr>
 <!--*** Visually verify flagged posts icon blue when active, tooltip "Flagged Posts"-->
 <!--Verify messaging with no posts flagged-->
+<!--** Hm, some previous test seems to have left a flagged DM. Unflag it manually-->
 <tr>
 	<td>waitForText</td>
 	<td>css=div.sidebar--right__subheader &gt; ul &gt; li &gt; span</td>
@@ -1460,7 +1451,7 @@
 	<td></td>
 </tr>
 <!--Markdown basics-->
-<!--*** NOTE: 4 images are broken (at the source); adding new samples-->
+<!--*** NOTE: several of the images are broken (at the source); adding new samples-->
 <!--*** https://github.com/mattermost/mattermost-server/pull/9802-->
 <tr>
 	<td>waitForElementPresent</td>

--- a/src/test/html/ide-only/Notifications/NotifyMan.html
+++ b/src/test/html/ide-only/Notifications/NotifyMan.html
@@ -157,7 +157,7 @@
 <!--*** Click back to Se browser-->
 <tr>
 	<td>pause</td>
-	<td>8000</td>
+	<td>10000</td>
 	<td></td>
 </tr>
 <!--Code block using triple ticks (there are also newlines in the value)-->
@@ -673,7 +673,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For mentions and direct messages, shown for 5 seconds</td>
+	<td>For mentions and direct messages</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>

--- a/src/test/html/ide-only/Notifications/NotifyMentions.html
+++ b/src/test/html/ide-only/Notifications/NotifyMentions.html
@@ -1031,14 +1031,14 @@
 	<td>exact:By using @all or @channel you are about to send notifications to 11 people. Are you sure you want to do this?</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>waitForValue</td>
@@ -1072,14 +1072,14 @@
 	<td>By using @all or @channel you are about to send notifications to 11 people. Are you sure you want to do this?</td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td></td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>Cancel</td>
 </tr>
 <tr>
 	<td>waitForValue</td>
@@ -1491,7 +1491,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=#desktopDesc &gt; span</td>
-	<td>For mentions and direct messages, shown for 5 seconds</td>
+	<td>For mentions and direct messages</td>
 </tr>
 <tr>
 	<td>waitForText</td>

--- a/src/test/html/ide-only/OB/OBTeamNameURL.html
+++ b/src/test/html/ide-only/OB/OBTeamNameURL.html
@@ -46,11 +46,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <!--Open Create a New Team link-->
 <tr>
 	<td>waitForElementPresent</td>

--- a/src/test/html/ide-only/Search/Search.html
+++ b/src/test/html/ide-only/Search/Search.html
@@ -103,12 +103,12 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=div.mentions__name.suggestion--selected</td>
-	<td>Off-Topic</td>
+	<td>Off-Topic*</td>
 </tr>
 <tr>
 	<td>click</td>
 	<td>css=div.mentions__name.suggestion--selected</td>
-	<td>Off-Topic</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForText</td>
@@ -1071,9 +1071,9 @@
 	<td>${KEY_DOWN}</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=div.search-autocomplete__item.selected</td>
-	<td>test2</td>
+	<td>waitForElementPresent</td>
+	<td>css=div.search-autocomplete__item.selected:contains('test2')</td>
+	<td></td>
 </tr>
 <!--Sleep-->
 <tr>
@@ -2000,7 +2000,7 @@
 <!--NOTE: Fails on postgres db unless Elasticsearch enabled-->
 <tr>
 	<td>waitForText</td>
-	<td>css=h4 &gt; span</td>
+	<td>css=div.sidebar--right__subheader &gt; h4 &gt; span</td>
 	<td>exact:No results found. Try again?</td>
 </tr>
 <!--Verify without quotes returns result-->

--- a/src/test/html/ide-only/Smoke/ST.html
+++ b/src/test/html/ide-only/Smoke/ST.html
@@ -168,11 +168,6 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
-	<td>id=tutorialIntroInvite</td>
-	<td></td>
-</tr>
-<tr>
-	<td>waitForElementPresent</td>
 	<td>link=feedback@mattermost.com</td>
 	<td></td>
 </tr>
@@ -448,12 +443,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>
@@ -1881,7 +1876,7 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<!--Open team invite link, create new account-->
+<!--Open STTeam invite link, create new account st2-->
 <tr>
 	<td>openAndWait</td>
 	<td>${teaminvitelink}</td>
@@ -2152,12 +2147,7 @@
 	<td>id=post_textbox</td>
 	<td>! Whole channel.${KEY_ENTER}</td>
 </tr>
-<!--Ah, this varies by server and has to be set in System Console to expect a confirm modal-->
-<tr>
-	<td>waitForText</td>
-	<td>css=span.mention--highlight &gt; span</td>
-	<td>@channel</td>
-</tr>
+<!--This will fail if the server is set in System Console to expect a confirm modal-->
 <!--Verify Main Menu options for non team admin (minimum; can vary)-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -2261,7 +2251,7 @@
 	<td></td>
 	<td></td>
 </tr>
-<!--Create new team from main menu-->
+<!--User st2 creates new team ST2Team from main menu-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>
@@ -2526,7 +2516,7 @@
 	<td>//div[2]/div/div/div[2]/div/ul/li[2]/a/span</td>
 	<td>Make Team Admin</td>
 </tr>
-<!--Set back to team member-->
+<!--Set user testst back to team member-->
 <tr>
 	<td>click</td>
 	<td>//div[2]/div/div/div[2]/div/ul/li[2]/a/span</td>
@@ -3110,7 +3100,7 @@
 	<td>css=div.setting-list__hint &gt; span</td>
 	<td>Set the name of the team as it appears on your sign-in screen and at the top of the left-hand sidebar.</td>
 </tr>
-<!--Change team name-->
+<!--Change team name from ST2Team to Core Test Team-->
 <tr>
 	<td>type</td>
 	<td>id=teamName</td>
@@ -3632,7 +3622,6 @@
 	<td>css=div.team-btn.team-btn__add</td>
 	<td></td>
 </tr>
-<!--This is set up with a team available to join; skip the next step if no teams available to join-->
 <tr>
 	<td>waitForText</td>
 	<td>css=a.signup-team-login &gt; span</td>
@@ -3675,14 +3664,19 @@
 	<td>plus</td>
 </tr>
 <tr>
-	<td>pause</td>
-	<td>4000</td>
+	<td>type</td>
+	<td>css=input.form-control</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>css=input.form-control</td>
 	<td></td>
 </tr>
 <tr>
 	<td>sendKeys</td>
 	<td>css=input.form-control</td>
-	<td>123</td>
+	<td>plus123</td>
 </tr>
 <tr>
 	<td>pause</td>
@@ -3734,7 +3728,7 @@
 	<td>4000</td>
 	<td></td>
 </tr>
-<!--Set team to be open to other users on the server-->
+<!--Set Plus team to be open to other users on the server-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>css=span.sidebar-header-dropdown__icon &gt; svg</td>
@@ -3928,6 +3922,7 @@
 </tr>
 <!--Verify mention badges - 2 on private channel, 1 on DM-->
 <!--*** This will fail if a different sidebar sort puts the 1 badge above the 2 badge-->
+<!--*** Can pause test and change sidebar to not show Unreads at top (until test is rewritten)-->
 <!--Open channels, verify message, verify badge disappears-->
 <tr>
 	<td>waitForText</td>
@@ -4005,7 +4000,7 @@
 	<td>css=strong.heading</td>
 	<td>Town Square</td>
 </tr>
-<!--LOG OUT testst, then in as ST2, to set team to be open to any user on the server-->
+<!--LOG OUT testst, then in as ST2, to set Core Test Team (ST2Test) to be open to any user on the server-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>
@@ -4970,14 +4965,7 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>link=Town Square</td>
-	<td>Town Square</td>
-</tr>
-<!--LM: I think this part isn't messed up anymore, but could use better notes-->
-<!--This part got mixed up as well  :/ Changed to STTeam but not sure-->
-<!--Oh, maybe this is supposed to be testst verifying st2 removed?-->
+<!--Verify removed from testchannel-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>//a[@href='/stteam']</td>
@@ -4998,7 +4986,7 @@
 	<td>link=${testchannel}</td>
 	<td></td>
 </tr>
-<!--This channel appears to actually be on Core Test Team? (Switching to Core team)-->
+<!--Switch to private channel on Core Test team-->
 <tr>
 	<td>waitForText</td>
 	<td>css=div.team-btn__initials</td>
@@ -5024,6 +5012,7 @@
 	<td>link=${privatechannel}*</td>
 	<td></td>
 </tr>
+<!--Marked as read, no mentions-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>link=${privatechannel}</td>

--- a/src/test/html/ide-only/SystemConsole/scExport.html
+++ b/src/test/html/ide-only/SystemConsole/scExport.html
@@ -242,7 +242,7 @@
 <tr>
 	<td>waitForText</td>
 	<td>css=span.status-icon-warning &gt; span</td>
-	<td>Pending</td>
+	<td>In Progress</td>
 </tr>
 <tr>
 	<td>waitForText</td>

--- a/src/test/html/ide-only/SystemConsole/scNotificationSettings.html
+++ b/src/test/html/ide-only/SystemConsole/scNotificationSettings.html
@@ -257,7 +257,7 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=div.announcement-bar.announcement-bar--fixed</td>
+	<td>css=p.markdown__paragraph-inline</td>
 	<td>Preview Mode: Email notifications have not been configured</td>
 </tr>
 <tr>
@@ -319,7 +319,7 @@
 <!--Verify banner disappeared-->
 <tr>
 	<td>waitForNotText</td>
-	<td>css=div.announcement-bar.announcement-bar--fixed</td>
+	<td>css=p.markdown__paragraph-inline</td>
 	<td>Preview Mode: Email notifications have not been configured</td>
 </tr>
 <!--Turn banner back on-->
@@ -355,7 +355,7 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=div.announcement-bar.announcement-bar--fixed</td>
+	<td>css=p.markdown__paragraph-inline</td>
 	<td>Preview Mode: Email notifications have not been configured</td>
 </tr>
 <!--Turn email notifications back on-->
@@ -467,7 +467,7 @@
 </tr>
 <tr>
 	<td>waitForNotText</td>
-	<td>css=div.announcement-bar</td>
+	<td>css=p.markdown__paragraph-inline</td>
 	<td>Preview Mode: Email notifications have not been configured×</td>
 </tr>
 <!--Enable email batching-->

--- a/src/test/html/ide-only/SystemConsole/scNotificationsMan.html
+++ b/src/test/html/ide-only/SystemConsole/scNotificationsMan.html
@@ -675,12 +675,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>No, keep it as &quot;Offline&quot;</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <!--Set to disable batching, send generic description-->
@@ -948,12 +948,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>No, keep it as &quot;Offline&quot;</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <!--Set to enable batching, send generic description-->
@@ -1083,12 +1083,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>No, keep it as &quot;Offline&quot;</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>
@@ -1386,12 +1386,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td>No, keep it as &quot;Offline&quot;</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
 	<td></td>
 </tr>
 <!--Set to enable batching, send full contents-->
@@ -1694,6 +1694,279 @@
 <!--***************************************************-->
 <!--***************************************************-->
 <!--*** Also verify came from Selenium Test Edit, address 398 Testing Blvd, Paradise-->
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<!--BATCHED, set to NEVER: Should not receive any email notifications-->
+<!--LOG IN first user (system admin) using stored creds-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=loginId</td>
+	<td>${firstuser}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=loginPassword</td>
+	<td>${firstpassword}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td>No, keep it as &quot;Offline&quot;</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.modal-footer &gt; button.btn.btn-link</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>2000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<!--Verify email batching is enabled (set to send every 15 minutes)-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=accountSettings</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=notificationsButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=notificationsButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#emailDesc &gt; span</td>
+	<td>Every 15 minutes</td>
+</tr>
+<!--Set to Never-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailEdit</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=emailNotificationNever</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=emailNotificationNever</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=emailNotificationNever</td>
+	<td>on</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=saveSetting</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementNotPresent</td>
+	<td>id=emailNotificationMinutes</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=#emailDesc &gt; span</td>
+	<td>Never</td>
+</tr>
+<!--LOG OUT first user-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<!--LOG IN second user using stored creds-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginId</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=loginId</td>
+	<td>${seconduser}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=loginPassword</td>
+	<td>${secondpassword}</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=loginButton</td>
+	<td></td>
+</tr>
+<!--Post an at-mention in public channel (Off-Topic)-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarSwitcherButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarSwitcherButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=input.form-control.focused</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>css=input.form-control.focused</td>
+	<td>off-to</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.mentions__name.suggestion--selected</td>
+	<td>Off-Topic</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.mentions__name.suggestion--selected</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>id=channelHeaderDropdownButton</td>
+	<td>Off-Topic</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=post_textbox</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>Batched! ${currentusername}, you should NOT receive an email notification for this.${KEY_ENTER}</td>
+</tr>
+<!--Send a DM-->
+<tr>
+	<td>waitForText</td>
+	<td>id=post_textbox</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>/msg ${currentusername} And here's a DM. Similarly, you should not receive an email notification for this either.${KEY_ENTER}</td>
+</tr>
+<!--LOG OUT other user-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=sidebarHeaderDropdownButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=logout</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>6000</td>
+	<td></td>
+</tr>
+<!--*******************************************************-->
+<!--*** PAUSE TEST HERE, wait for 15 or 20 minutes-->
+<!--*** Verify NO EMAIL notification received for the at-mention or DM-->
+<!--*******************************************************-->
 <tr>
 	<td></td>
 	<td></td>

--- a/src/test/html/ide-only/SystemConsole/scPlugins.html
+++ b/src/test/html/ide-only/SystemConsole/scPlugins.html
@@ -525,6 +525,527 @@
 	<td>http://selenium.mattermost.com/admin_console/plugins/management</td>
 	<td></td>
 </tr>
+<!--Upload the 'original' giphy plugin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=documentation</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotEditable</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=input[type=&quot;file&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=input[type=&quot;file&quot;]</td>
+	<td></td>
+</tr>
+<!--*** Manually select com.mattermost.giphy-plugin-ORIGINAL-0.0.1.tar.gz (in Resources)-->
+<tr>
+	<td>pause</td>
+	<td>7000</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td>Upload</td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--This step usually takes a while to finish uploading-->
+<tr>
+	<td>waitForNotEditable</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--Enable Giphy plugin-->
+<!--Giphy should be first plugin in the list; if not this command may fail-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.padding-top &gt; a &gt; span</td>
+	<td>Enable</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.padding-top &gt; a &gt; span</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.alert.alert-success &gt; span</td>
+	<td>This plugin is running.</td>
+</tr>
+<!--Return to team to verify /giphy-->
+<tr>
+	<td>waitForText</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=post_textbox</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>/giph</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.command.suggestion--selected</td>
+	<td>/giphy [search string]<br />Unleashes the magic of Giphy</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>y installed and enabled original</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=post_textbox</td>
+	<td>/giphy installed and enabled original</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>${KEY_ENTER}</td>
+</tr>
+<tr>
+	<td>waitForTextPresent</td>
+	<td>installed and enabled original*(Posted using - ORIGINAL - /giphy)</td>
+	<td></td>
+</tr>
+<!--Delete message after verification to avoid future false positive-->
+<tr>
+	<td>rollup</td>
+	<td>openDotMenuForLastPost</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.style--none span:contains('Delete')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.style--none span:contains('Delete')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-body &gt; span</td>
+	<td>exact:Are you sure you want to delete this Post?</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTextNotPresent</td>
+	<td>installed and enabled original*(Posted using - ORIGINAL - /giphy)</td>
+	<td></td>
+</tr>
+<!--Upload the updated giphy plugin and accept overwrite prompt-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=input[type=&quot;file&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=input[type=&quot;file&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>7000</td>
+	<td></td>
+</tr>
+<!--*** Manually select com.mattermost.giphy-plugin-OVERWRITTEN-0.0.1.tar.gz (in Resources)-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td>Upload</td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--This step usually takes a while to finish uploading-->
+<!--Click Overwrite at overwrite prompt-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-body &gt; span</td>
+	<td>exact:A plugin with this ID already exists. Would you like to overwrite it?</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-danger</td>
+	<td>Overwrite</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<!--Plugin update success message-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.form-group.half</td>
+	<td>Successfully updated plugin from *</td>
+</tr>
+<!--Giphy plugin should still be enabled-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.alert.alert-success &gt; span</td>
+	<td>This plugin is running.</td>
+</tr>
+<!--Return to team to verify /giphy after overwrite-->
+<tr>
+	<td>waitForText</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=post_textbox</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>/giph</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.command.suggestion--selected</td>
+	<td>/giphy [search string]<br />Unleashes the magic of Giphy</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>y installed overwritten plugin</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=post_textbox</td>
+	<td>/giphy installed overwritten plugin</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>${KEY_ENTER}</td>
+</tr>
+<tr>
+	<td>waitForTextPresent</td>
+	<td>installed overwritten plugin*(Posted using - OVERWRITTEN - /giphy)</td>
+	<td></td>
+</tr>
+<!--Delete message after verification to avoid future false positive-->
+<tr>
+	<td>rollup</td>
+	<td>openDotMenuForLastPost</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.style--none span:contains('Delete')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.style--none span:contains('Delete')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-body &gt; span</td>
+	<td>exact:Are you sure you want to delete this Post?</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTextNotPresent</td>
+	<td>installed overwritten plugin*(Posted using - OVERWRITTEN - /giphy)</td>
+	<td></td>
+</tr>
+<!--Reinstall original version-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=input[type=&quot;file&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=input[type=&quot;file&quot;]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>pause</td>
+	<td>7000</td>
+	<td></td>
+</tr>
+<!--*** Manually select com.mattermost.giphy-plugin-ORIGINAL-0.0.1.tar.gz (in Resources)-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td>Upload</td>
+</tr>
+<tr>
+	<td>waitForEditable</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td></td>
+</tr>
+<!--This step usually takes a while to finish uploading-->
+<!--Click Overwrite at overwrite prompt-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-body &gt; span</td>
+	<td>exact:A plugin with this ID already exists. Would you like to overwrite it?</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-danger</td>
+	<td>Overwrite</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<!--Plugin update success message-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.form-group.half</td>
+	<td>Successfully updated plugin from *</td>
+</tr>
+<!--Giphy plugin should still be enabled-->
+<tr>
+	<td>waitForText</td>
+	<td>css=div.alert.alert-success</td>
+	<td>This plugin is running.</td>
+</tr>
+<!--Return to team to verify /giphy returns Original text-->
+<tr>
+	<td>waitForText</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=swithToui-automation</td>
+	<td>Switch to UI Automation</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=post_textbox</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>/giph</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.command.suggestion--selected</td>
+	<td>/giphy [search string]<br />Unleashes the magic of Giphy</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>y installed and enabled original</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=post_textbox</td>
+	<td>/giphy installed and enabled original</td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>${KEY_ENTER}</td>
+</tr>
+<tr>
+	<td>waitForTextPresent</td>
+	<td>installed and enabled original*(Posted using - ORIGINAL - /giphy)</td>
+	<td></td>
+</tr>
+<!--Delete message after verification to avoid future false positive-->
+<tr>
+	<td>rollup</td>
+	<td>openDotMenuForLastPost</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.style--none span:contains('Delete')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.style--none span:contains('Delete')</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.modal-body &gt; span</td>
+	<td>exact:Are you sure you want to delete this Post?</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-danger</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTextNotPresent</td>
+	<td>installed and enabled original*(Posted using - ORIGINAL - /giphy)</td>
+	<td></td>
+</tr>
+<!--Cleanup: Remove Giphy plugin-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=systemConsole</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=management</td>
+	<td></td>
+</tr>
+<!--Again, assumes Giphy is first in list (it should be on Se)-->
+<tr>
+	<td>waitForText</td>
+	<td>css=span &gt; a &gt; span</td>
+	<td>Remove</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=span &gt; a &gt; span</td>
+	<td>Remove</td>
+</tr>
+<tr>
+	<td>waitForTextNotPresent</td>
+	<td>Giphy</td>
+	<td></td>
+</tr>
+<!--DEMO PLUGIN-->
 <!--Verify can upload the demo plugin-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -594,7 +1115,7 @@
 	<td>css=div.padding-top:contains('This plugin demonstrates the capabilities of a Mattermost plugin.')</td>
 	<td></td>
 </tr>
-<!--Can't upload the same plugin twice-->
+<!--Uploading the same plugin twice prompts to overwrite (new behavior v5.8)-->
 <tr>
 	<td>waitForElementPresent</td>
 	<td>css=input[type=&quot;file&quot;]</td>
@@ -626,16 +1147,27 @@
 	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
 	<td></td>
 </tr>
-<tr>
-	<td>waitForElementPresent</td>
-	<td>//label[@class='control-label']</td>
-	<td></td>
-</tr>
 <!--This step usually takes a while to finish uploading-->
+<!--Cancel out of overwrite prompt-->
 <tr>
 	<td>waitForText</td>
-	<td>//label[@class='control-label']</td>
-	<td>Unable to install plugin. A plugin with the same ID is already installed.</td>
+	<td>css=div.modal-body &gt; span</td>
+	<td>exact:A plugin with this ID already exists. Would you like to overwrite it?</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=button.btn.btn-link</td>
+	<td>Cancel</td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>css=button.btn.btn-link</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForNotText</td>
+	<td>css=div.col-sm-8 &gt; button.btn.btn-primary</td>
+	<td>Upload</td>
 </tr>
 <!--Enable demo-plugin-->
 <tr>
@@ -1640,6 +2172,47 @@
 	<td>Click anywhere to close</td>
 	<td></td>
 </tr>
+<!--File upload action option-->
+<tr>
+	<td>waitForElementPresent</td>
+	<td>id=fileUploadButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>id=fileUploadButton</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>link=Upload using Demo Plugin</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>link=Upload using Demo Plugin</td>
+	<td></td>
+</tr>
+<tr>
+	<td>waitForTextPresent</td>
+	<td></td>
+	<td>You have triggered the root component of the demo plugin.<br /><br />Click anywhere to close.</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
+	<td>//div[@id='channel_view']/div/div[6]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>click</td>
+	<td>//div[@id='channel_view']/div/div[6]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>verifyTextNotPresent</td>
+	<td>Click anywhere to close</td>
+	<td></td>
+</tr>
 <!--demo_plugin settings page in System Console-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -1744,9 +2317,6 @@
 	<td>css=div.sidebar--left__icons &gt; div</td>
 	<td>Demo Plugin: Enabled</td>
 </tr>
-<!--*** Testing 5.6.2 I see different behavior here: Disabled plugin-->
-<!--*** and tried slash command. Autocomplete still appears, and -->
-<!--*** trying to run it results in message "An error occurred while trying to execute this command."-->
 <!--/plugin_demo command no longer found-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -1835,12 +2405,32 @@
 	<td></td>
 </tr>
 <tr>
+	<td>waitForElementPresent</td>
+	<td>id=post_textbox</td>
+	<td></td>
+</tr>
+<tr>
+	<td>sendKeys</td>
+	<td>id=post_textbox</td>
+	<td>/demo_p</td>
+</tr>
+<tr>
+	<td>waitForValue</td>
+	<td>id=post_textbox</td>
+	<td>/demo_p</td>
+</tr>
+<tr>
+	<td>waitForText</td>
+	<td>css=div.command__title</td>
+	<td>/demo_plugin (true|false)</td>
+</tr>
+<tr>
 	<td></td>
 	<td></td>
 	<td></td>
 </tr>
 <!--*** Plugin is removed in tests below; if you still have manual -->
-<!--*** tests to do, Don't run the below test to remove the plugin-->
+<!--*** tests to do, Don't run the below test to remove the plugin yet-->
 <tr>
 	<td></td>
 	<td></td>


### PR DESCRIPTION
- AuthSaml: Use dynamic channel name
- ChannelConvertPub...: Cancel button CSS changed
- ChannelNotificationsUI: Removed references to "shown for 5 seconds"
- ChannelSettingsPriHeader: Cancel button CSS changed
- ChannelSettingsPurpose: Cancel button CSS changed
- EmailVerifyMan: Add temp credentials steps
- channelSidebar: Cancel button CSS changed
- IntegrationsSlashCmds: Cancel button CSS changed
- KeyShortcutsUp: Cancel button CSS changed
- MessagingBasics: Add password to email update, Cancel button CSS
changed
- MessagingEdit: Cancel button CSS changed
- M.EmojiCustomMan: Cancel button CSS changed, use rollups, update some
helper text
- MessagingMan: Cancel button CSS changed
- NotifyMan: Removed "shown for 5 seconds"
- NotifyMentions: Cancel button CSS changed
- OBTeamNameURL: Remove verification of Town Square on reopening
- Search: CSS changed for a couple elements
- ST: Cancel button CSS changed, corrected some in-test comments
- scExport: Job table text changed
- scNotificationSettings: Banner CSS changed
- scNotificationsMan: Added test for set to Never, Cancel button CSS
changed
- scPlugins: Added Giphy plugin