### PR TITLE
More updates from 5.8 testing

### DIFF
--- a/src/test/html/ide-only/SystemConsole/scRestrictAcctDomain.html
+++ b/src/test/html/ide-only/SystemConsole/scRestrictAcctDomain.html
@@ -47,11 +47,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>
 	<td></td>
@@ -230,11 +225,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>
@@ -506,6 +496,16 @@
 </tr>
 <tr>
 	<td>waitForElementPresent</td>
+	<td>id=currentPassword</td>
+	<td></td>
+</tr>
+<tr>
+	<td>type</td>
+	<td>id=currentPassword</td>
+	<td>passwd</td>
+</tr>
+<tr>
+	<td>waitForElementPresent</td>
 	<td>id=saveSetting</td>
 	<td></td>
 </tr>
@@ -573,11 +573,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>

--- a/src/test/html/ide-only/SystemConsole/scSecSignup.html
+++ b/src/test/html/ide-only/SystemConsole/scSecSignup.html
@@ -730,12 +730,6 @@
 </tr>
 <!--LOG IN admin-->
 <tr>
-	<td>openAndWait</td>
-	<td>/login</td>
-	<td></td>
-</tr>
-<!--DisableAnimations-->
-<tr>
 	<td>waitForElementPresent</td>
 	<td>css=button.btn.btn-primary</td>
 	<td></td>
@@ -754,19 +748,6 @@
 	<td>click</td>
 	<td>id=loginButton</td>
 	<td></td>
-</tr>
-<tr>
-	<td>pause</td>
-	<td>3000</td>
-	<td></td>
-</tr>
-<!--Sleep-->
-<!--Sleep-->
-<!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersDeactivate.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersDeactivate.html
@@ -608,6 +608,7 @@
 	<td>id=channelHeaderDropdownButton</td>
 	<td>test2, test3</td>
 </tr>
+<!--This can fail if other testing has caused test2 to already be in LHS-->
 <!--DM has been removed from LHS-->
 <tr>
 	<td>waitForElementNotPresent</td>
@@ -669,7 +670,7 @@
 </tr>
 <tr>
 	<td>waitForTextPresent</td>
-	<td>@test2 - Deactivated</td>
+	<td>@test2 - *Deactivated</td>
 	<td></td>
 </tr>
 <tr>
@@ -722,11 +723,6 @@
 	<td>waitForText</td>
 	<td>css=div.more-modal__name &gt; span</td>
 	<td>@test2 - *Deactivated</td>
-</tr>
-<tr>
-	<td>waitForElementPresent</td>
-	<td>id=saveItems</td>
-	<td></td>
 </tr>
 <tr>
 	<td>click</td>
@@ -1161,6 +1157,7 @@
 	<td>id=channelHeaderDropdownButton</td>
 	<td>test2</td>
 </tr>
+<!--This can fail if other testing has caused other archived icons to display-->
 <tr>
 	<td>waitForElementNotPresent</td>
 	<td>css=span.icon.icon__archive &gt; svg &gt; path</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersEmail.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersEmail.html
@@ -46,11 +46,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <!--LOG OUT test2-->
 <tr>
 	<td>pause</td>
@@ -118,11 +113,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <!--Open System Console-->
 <tr>
 	<td>waitForElementPresent</td>
@@ -246,12 +236,12 @@
 </tr>
 <tr>
 	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=button.btn.btn-link</td>
 	<td>Cancel</td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
+	<td>css=button.btn.btn-link</td>
 	<td></td>
 </tr>
 <tr>
@@ -627,11 +617,6 @@
 <!--Sleep-->
 <!--Sleep-->
 <!--Sleep-->
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
 <!--Open System Console-->
 <tr>
 	<td>waitForElementPresent</td>

--- a/src/test/html/ide-only/SystemConsole/scUsersTeamsDM.html
+++ b/src/test/html/ide-only/SystemConsole/scUsersTeamsDM.html
@@ -651,11 +651,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
-</tr>
-<tr>
 	<td>waitForElementPresent</td>
 	<td>id=sidebarHeaderDropdownButton</td>
 	<td></td>
@@ -951,11 +946,6 @@
 	<td>click</td>
 	<td>id=loginButton</td>
 	<td></td>
-</tr>
-<tr>
-	<td>waitForText</td>
-	<td>css=strong.heading</td>
-	<td>Town Square</td>
 </tr>
 <tr>
 	<td>waitForElementPresent</td>

--- a/src/test/html/ide-only/Team/TeamSettings.html
+++ b/src/test/html/ide-only/Team/TeamSettings.html
@@ -759,14 +759,14 @@
 	<td>exact:You will be removed from all public and private channels. If the team is private you will not be able to rejoin the team. Are you sure?</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
-	<td>No</td>
+	<td>waitForElementPresent</td>
+	<td>id=leaveTeamNo</td>
+	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td>No</td>
+	<td>id=leaveTeamNo</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForText</td>
@@ -2119,16 +2119,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>waitForElementPresent</td>
-	<td>css=input.form-control.filter-textbox</td>
-	<td></td>
-</tr>
-<tr>
-	<td>sendKeys</td>
-	<td>css=input.form-control.filter-textbox</td>
-	<td>test6</td>
-</tr>
-<tr>
 	<td>waitForText</td>
 	<td>css=a.dropdown-toggle.theme &gt; span &gt; span</td>
 	<td>Inactive</td>
@@ -2905,6 +2895,8 @@
 	<td>css=p &gt; span</td>
 	<td>The team you're requesting is private or does not exist. Please contact your Administrator for an invitation.</td>
 </tr>
+<!--This may fail if running after custom branding test; with site name not set-->
+<!--it just says "Back to" - open ticket to address this: MM-13694-->
 <tr>
 	<td>waitForText</td>
 	<td>css=a &gt; span</td>

--- a/src/test/html/ide-only/Team/TeamSettingsEnableJoin.html
+++ b/src/test/html/ide-only/Team/TeamSettingsEnableJoin.html
@@ -259,14 +259,14 @@
 	<td>exact:You will be removed from all public and private channels. If the team is private you will not be able to rejoin the team. Are you sure?</td>
 </tr>
 <tr>
-	<td>waitForText</td>
-	<td>css=button.btn.btn-default</td>
-	<td>No</td>
+	<td>waitForElementPresent</td>
+	<td>id=leaveTeamNo</td>
+	<td></td>
 </tr>
 <tr>
 	<td>click</td>
-	<td>css=button.btn.btn-default</td>
-	<td>No</td>
+	<td>id=leaveTeamNo</td>
+	<td></td>
 </tr>
 <tr>
 	<td>waitForText</td>


### PR DESCRIPTION
Mostly removing Town Square verification on login and updating locator for Cancel button:
- scRestrictAcctDomain: Remove Town Square verification on login
- scSecSignup: Remove Town Square verification on login
- scUsersDeactivate: Make finding Deactivated less brittle
- scUsersEmail: Remove Town Square verification on login, Cancel button
CSS changed
- scUsersTeamsDM: Remove Town Square verification on login
- TeamSettings: Cancel button CSS changed
- TeamSettingsEnableJoin: Cancel button CSS changed