### PR TITLE
Update selenium to 3.141.59-zinc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,8 @@ test-firefox: patch-files
 	mvn -Dbrowser=firefox clean verify
 
 test-all: patch-files
+	# Log google chroe version
+	google-chrome --version
+
 	#mvn -Dbrowser=firefox clean verify
 	mvn -Dbrowser=chrome clean verify

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
 seleniumhub:
-  image: selenium/hub:3.0.0-cerium
+  image: selenium/hub:3.141.59-zinc
   ports:
     - 4444:4444
 
 firefoxnode:
-  image: selenium/node-firefox:3.0.0-cerium
+  image: selenium/node-firefox:3.141.59-zinc
   ports:
     - 5900
   links:
     - seleniumhub:hub
 
 chromenode:
-  image: selenium/node-chrome:3.0.0-cerium
+  image: selenium/node-chrome:3.141.59-zinc
   ports:
     - 5900
   links:


### PR DESCRIPTION
#### Summary
`3.0.0-cerium` is no longer compatible with current google-chrome-stable version.  This PR fixes the compatibility issue but will observe other selenium that might need to be updated as well.